### PR TITLE
Utilize composer's 'bin' property for global installs.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,6 @@
     "psr-4": {
       "Dorgflow\\": ""
     }
-  }
+  },
+  "bin": ["dorgflow"]
 }

--- a/dorgflow
+++ b/dorgflow
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 $container = new ContainerBuilder();
 // Don't bother with PhpFileLoader; it's overkill.
-require 'services.php';
+require __DIR__ . '/services.php';
 
 print "Hello, this is Dorgflow!\n";
 


### PR DESCRIPTION
This change makes use of [composer](https://getcomposer.org/doc/articles/vendor-binaries.md)'s `bin` property so that when installing globally, or as part of another project, the binary is properly symlinked into the bin directory (typically `vendor/bin`).

I wonder if for backward compatibility if we should symlink the binary back into the root directory?