### PR TITLE
Windows support and Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: php
+
+php:
+  - 7.3
+  - 7.2
+  - 7.1
+  - 7.0
+
+before_install:
+  - composer install --no-interaction --no-progress --quiet
+
+script:
+  - vendor/bin/phpunit tests

--- a/Service/GitExecutor.php
+++ b/Service/GitExecutor.php
@@ -205,7 +205,7 @@ class GitExecutor {
   public function commit($message) {
     // Allow empty commits, for local patches and also in case two sequential
     // patches are identical.
-    shell_exec("git commit  --allow-empty --message='$message'");
+    shell_exec(sprintf('git commit  --allow-empty "--message=%s"', $message));
   }
 
   /**

--- a/Service/GitInfo.php
+++ b/Service/GitInfo.php
@@ -83,7 +83,7 @@ class GitInfo {
       $branch_list = [];
 
       // Get the list of local branches as 'SHA BRANCHNAME'.
-      $refs = shell_exec("git for-each-ref refs/heads/ --format='%(objectname) %(refname:short)'");
+      $refs = shell_exec('git for-each-ref refs/heads/ "--format=%(objectname) %(refname:short)"');
       foreach (explode("\n", trim($refs)) as $line) {
         list($sha, $branch_name) = explode(' ', $line);
 

--- a/Service/GitLog.php
+++ b/Service/GitLog.php
@@ -67,7 +67,7 @@ class GitLog {
    *  The raw output from git rev-list.
    */
   protected function getLog($old, $new) {
-    $git_log = shell_exec("git rev-list {$new} ^{$old} --pretty=oneline --reverse");
+    $git_log = shell_exec("git rev-list {$new} \"^{$old}\" --pretty=oneline --reverse");
 
     return $git_log;
   }
@@ -87,7 +87,8 @@ class GitLog {
     $feature_branch_log = [];
 
     if (!empty($log)) {
-      $git_log_lines = explode("\n", rtrim($log));
+      $any_newline = '/\r\n|\n/';
+      $git_log_lines = preg_split($any_newline, rtrim($log));
       foreach ($git_log_lines as $line) {
         list($sha, $message) = explode(' ', $line, 2);
         //dump("$sha ::: $message");

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,10 @@
     "psr-4": {
       "Dorgflow\\": ""
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Dorgflow\\Tests\\": "tests"
+    }
   }
 }


### PR DESCRIPTION
This pull request adds Windows support (details in the commit message).

To prove that I didn't destroy Linux support on the way, I manually tested things and added Travis CI coverage to my fork of this repo. See https://travis-ci.com/Fonata/dorgflow/builds/102212670 for some test output.

@joachim-n If you decide to merge this, you probably have to allow Travis to access your repo. It will set up a hook automatically to run unit tests on each push and each pull request.