### PR TITLE
Add support for Symfony 5

### DIFF
--- a/Command/Apply.php
+++ b/Command/Apply.php
@@ -71,6 +71,8 @@ class Apply extends SymfonyCommand implements ContainerAwareInterface {
     print strtr("You should now commit this, using the command from the issue on drupal.org: https://www.drupal.org/node/!id#drupalorg-issue-credit-form.\n", [
       '!id' => $this->analyser->deduceIssueNumber(),
     ]);
+
+    return 0;
   }
 
 }

--- a/Command/Cleanup.php
+++ b/Command/Cleanup.php
@@ -50,13 +50,15 @@ class Cleanup extends SymfonyCommand implements ContainerAwareInterface {
 
     if ($confirmation != 'delete') {
       print "Clean up aborted.\n";
-      return;
+      return 0;
     }
 
     $master_branch_name = $master_branch->getBranchName();
     shell_exec("git checkout $master_branch_name");
 
     shell_exec("git branch -D $feature_branch_name");
+
+    return 0;
 
     // TODO: delete any patch files for this issue.
   }

--- a/Command/CreatePatch.php
+++ b/Command/CreatePatch.php
@@ -105,6 +105,8 @@ class CreatePatch extends SymfonyCommand implements ContainerAwareInterface {
     // Make an empty commit to record the patch.
     $local_patch_commit_message = $this->commit_message->createLocalCommitMessage($local_patch);
     $this->git_executor->commit($local_patch_commit_message);
+
+    return 0;
   }
 
   protected function getInterdiffName($feature_branch, $last_patch) {

--- a/Command/Diff.php
+++ b/Command/Diff.php
@@ -53,6 +53,8 @@ class Diff extends SymfonyCommand implements ContainerAwareInterface {
     $diff = $this->git_info->diffMasterBranch($master_branch->getBranchName());
 
     $io->text($diff);
+
+    return 0;
   }
 
 }

--- a/Command/LocalSetup.php
+++ b/Command/LocalSetup.php
@@ -63,7 +63,7 @@ class LocalSetup extends SymfonyCommand implements ContainerAwareInterface {
         $output->writeln("Afterwards, you should use the update command to get new patches from drupal.org.");
       }
 
-      return;
+      return 0;
     }
 
     // If the master branch is not current, abort.
@@ -89,7 +89,7 @@ class LocalSetup extends SymfonyCommand implements ContainerAwareInterface {
     // If no patches, we're done.
     if (empty($patches)) {
       $output->writeln("There are no patches to apply.");
-      return;
+      return 0;
     }
 
     // Output the patches.
@@ -122,6 +122,8 @@ class LocalSetup extends SymfonyCommand implements ContainerAwareInterface {
         '!patchname' => $patch->getPatchFilename(),
       ]));
     }
+
+    return 0;
   }
 
 }

--- a/Command/LocalUpdate.php
+++ b/Command/LocalUpdate.php
@@ -59,7 +59,7 @@ class LocalUpdate extends SymfonyCommand implements ContainerAwareInterface {
     // If no patches, we're done.
     if (empty($patches)) {
       print "No patches to apply.\n";
-      return;
+      return 0;
     }
 
     $patches_uncommitted = [];
@@ -86,7 +86,7 @@ class LocalUpdate extends SymfonyCommand implements ContainerAwareInterface {
     // If no uncommitted patches, we're done.
     if (empty($patches_uncommitted)) {
       print "No patches to apply; existing patches are already applied to this feature branch.\n";
-      return;
+      return 0;
     }
 
     // If the feature branch's SHA is not the same as the last committed patch
@@ -134,7 +134,7 @@ class LocalUpdate extends SymfonyCommand implements ContainerAwareInterface {
     // If all the patches were already committed, we're done.
     if (empty($patches_committed)) {
       print "No new patches to apply.\n";
-      return;
+      return 0;
     }
 
     // If final patch didn't apply, then output a message: the latest patch
@@ -149,6 +149,8 @@ class LocalUpdate extends SymfonyCommand implements ContainerAwareInterface {
         '!patchname' => $patch->getPatchFilename(),
       ]);
     }
+
+    return 0;
   }
 
 }

--- a/Command/Purge.php
+++ b/Command/Purge.php
@@ -73,7 +73,7 @@ class Purge extends SymfonyCommand implements ContainerAwareInterface {
 
     if (empty($issues_to_clean_up)) {
       print "No branches to clean up.\n";
-      return;
+      return 0;
     }
 
     // Sort by issue number.
@@ -102,13 +102,15 @@ class Purge extends SymfonyCommand implements ContainerAwareInterface {
     $question = new Question("Please enter 'delete' to confirm DELETION of {$count} branches:");
     if ($helper->ask($input, $output, $question) != 'delete') {
       $output->writeln('Clean up aborted.');
-      return;
+      return 0;
     }
 
     foreach ($issues_to_clean_up as $issue_number => $info) {
       shell_exec("git branch -D {$info['branch']}");
       $output->writeln("Deleted branch {$info['branch']}.");
     }
+
+    return 0;
   }
 
   protected function getIssueCommit($issue_number) {

--- a/Command/Status.php
+++ b/Command/Status.php
@@ -70,6 +70,8 @@ class Status extends SymfonyCommand implements ContainerAwareInterface {
     if (!$clean) {
       $io->text('You have uncommitted changes.');
     }
+
+    return 0;
   }
 
 }

--- a/Command/SwitchMaster.php
+++ b/Command/SwitchMaster.php
@@ -42,6 +42,8 @@ class SwitchMaster extends SymfonyCommand implements ContainerAwareInterface {
 
     $master_branch = $this->waypoint_manager_branches->getMasterBranch();
     $master_branch->gitCheckout();
+
+    return 0;
   }
 
 }


### PR DESCRIPTION
## Purpose:
- When running composer install after a fresh clone down of the repository errors are thrown.

## Fixes:
- Fixes #51 

## Solution:
- Force fresh installs to use Symfony version less than 5.